### PR TITLE
Make the OSNI download URL a variable

### DIFF
--- a/check-osni-downloads
+++ b/check-osni-downloads
@@ -15,10 +15,10 @@ export osni_folder="OSNI"
 export osni_prefix="OSNI_Open_Data_Largescale_Boundaries_"
 osni_present=0
 
-OSNI_URL=https://s3.amazonaws.com/gds-public-readable-tarballs/govuk-mapit/20160902-osni-dec-2015.tar.gz
+OSNI_URL=http://parlvid.mysociety.org/os/osni-dec-2015.tar.gz
 
 OSNI_FILE_NAME=$(basename $OSNI_URL)
-echo "Fetching OSNI from our S3 bucket"
+echo "Fetching OSNI data"
 if [ ! -e $OSNI_FILE_NAME ]; then
     curl -O $OSNI_URL
 fi

--- a/check-osni-downloads
+++ b/check-osni-downloads
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+set -eu
+set -o pipefail
+
 declare -A osni_types
 export osni_types=( \
   ["wmc"]='_Parliamentary_Constituencies_2008' \
@@ -11,12 +15,16 @@ export osni_folder="OSNI"
 export osni_prefix="OSNI_Open_Data_Largescale_Boundaries_"
 osni_present=0
 
-echo "Downloading OSNI from mysociety cache"
-if [ ! -e 20160902-osni-dec-2015.tar.gz ]; then
-    curl -O https://s3.amazonaws.com/gds-public-readable-tarballs/govuk-mapit/20160902-osni-dec-2015.tar.gz
+OSNI_URL=https://s3.amazonaws.com/gds-public-readable-tarballs/govuk-mapit/20160902-osni-dec-2015.tar.gz
+
+OSNI_FILE_NAME=$(basename $OSNI_URL)
+echo "Fetching OSNI from our S3 bucket"
+if [ ! -e $OSNI_FILE_NAME ]; then
+    curl -O $OSNI_URL
 fi
+
 mkdir -p $osni_folder
-tar xvzf 20160902-osni-dec-2015.tar.gz --transform "s-^[^/]+(/|$)-$osni_folder/-x" --show-transformed-names
+tar xvzf $OSNI_FILE_NAME --transform "s-^[^/]+(/|$)-$osni_folder/-x" --show-transformed-names
 
 for osni_type in "${!osni_types[@]}"
 do


### PR DESCRIPTION
The docs for importing data say "Update the script in to refer to the URLs of the new releases", but this is currently more difficult than it should be because multiple lines need to be changed. This PR changes it so only one line needs to be changed, the URL.

I've also made sure the script fails early if there are any problems.

In the future my plan is to update all the scripts to take these URLs from the environment or arguments.

[Trello Card](https://trello.com/c/eCBcegb3/781-dry-run-of-importing-ons-postcode-and-os-boundary-line-data)