### PR TITLE
Remove references to the Dev VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,6 @@ It downloads local authority slugs from the GOV.UK Frontend app and assigns them
 
 It does not use Code-Point data (unlike `import-uk`)
 
-find-mapit-venv
----------------
-The virtual env directory is likely to be either `.venv` (on the Dev VM) or
-`venv` on a deployed machine.  This script will find either, and allows for it
- to be arbitrarily set via the `MAPIT_VENV_DIR` environment variable.
-
 setup-and-import-uk
 -------------------
 _This script is not currently used for our production data set - please see

--- a/find-mapit-managepy
+++ b/find-mapit-managepy
@@ -1,0 +1,8 @@
+if [ -f /.dockerenv ]; then
+  # Docker environment
+   export MANAGE="/govuk/mapit/manage.py"
+else
+  # Non-Docker environment
+  source ./find-mapit-venv
+  export MANAGE="/usr/local/bin/govuk_setenv mapit $MAPIT_VENV_DIR/bin/python /var/apps/mapit/manage.py"
+fi

--- a/import-uk
+++ b/import-uk
@@ -6,14 +6,7 @@
 
 set -e
 
-if [ -f /.dockerenv ]; then
-  # Docker environment
-   export MANAGE="/govuk/mapit/manage.py"
-else
-  # Non-Docker environment
-  source ./find-mapit-venv
-  export MANAGE="/usr/local/bin/govuk_setenv mapit $MAPIT_VENV_DIR/bin/python /var/apps/mapit/manage.py"
-fi
+source ./find-mapit-managepy
 
 # Okay, let's start the import. Instructions taken from
 # http://code.mapit.mysociety.org/import/uk/

--- a/import-uk
+++ b/import-uk
@@ -6,9 +6,14 @@
 
 set -e
 
-source ./find-mapit-venv
-
-export MANAGE="/usr/local/bin/govuk_setenv mapit $MAPIT_VENV_DIR/bin/python /var/apps/mapit/manage.py"
+if [ -f /.dockerenv ]; then
+  # Docker environment
+   export MANAGE="/govuk/mapit/manage.py"
+else
+  # Non-Docker environment
+  source ./find-mapit-venv
+  export MANAGE="/usr/local/bin/govuk_setenv mapit $MAPIT_VENV_DIR/bin/python /var/apps/mapit/manage.py"
+fi
 
 # Okay, let's start the import. Instructions taken from
 # http://code.mapit.mysociety.org/import/uk/

--- a/import-uk-onspd
+++ b/import-uk-onspd
@@ -6,14 +6,7 @@
 
 set -e
 
-if [ -f /.dockerenv ]; then
-  # Docker environment
-   export MANAGE="/govuk/mapit/manage.py"
-else
-  # Non-Docker environment
-  source ./find-mapit-venv
-  export MANAGE="/usr/local/bin/govuk_setenv mapit $MAPIT_VENV_DIR/bin/python /var/apps/mapit/manage.py"
-fi
+source ./find-mapit-managepy
 
 BD_LINE_URL=https://s3-eu-west-1.amazonaws.com/govuk-custom-formats-mapit-storage-production/source-data/2019-08/bdline_gb-2019-05.zip
 ONSPD_URL=https://s3-eu-west-1.amazonaws.com/govuk-custom-formats-mapit-storage-production/source-data/2019-08/ONSPD_AUG_2019_UK.zip

--- a/import-uk-onspd
+++ b/import-uk-onspd
@@ -6,9 +6,14 @@
 
 set -e
 
-source ./find-mapit-venv
-
-export MANAGE="/usr/local/bin/govuk_setenv mapit $MAPIT_VENV_DIR/bin/python /var/apps/mapit/manage.py"
+if [ -f /.dockerenv ]; then
+  # Docker environment
+   export MANAGE="/govuk/mapit/manage.py"
+else
+  # Non-Docker environment
+  source ./find-mapit-venv
+  export MANAGE="/usr/local/bin/govuk_setenv mapit $MAPIT_VENV_DIR/bin/python /var/apps/mapit/manage.py"
+fi
 
 BD_LINE_URL=https://s3-eu-west-1.amazonaws.com/govuk-custom-formats-mapit-storage-production/source-data/2019-08/bdline_gb-2019-05.zip
 ONSPD_URL=https://s3-eu-west-1.amazonaws.com/govuk-custom-formats-mapit-storage-production/source-data/2019-08/ONSPD_AUG_2019_UK.zip


### PR DESCRIPTION
The dev VM has been deprecated as we now use Docker for local
development.

Adding a check to detect whether the environment is using Docker
allows us to set the `$MANAGE` environment appropriately, as we
may still use the `venv` commands in some places.

Trello card: https://trello.com/c/mJVTfjjd/1719-8-import-mapit-data-using-docker-%F0%9F%8D%90

Related PR : https://github.com/alphagov/govuk-docker/pull/309