### PR TITLE
Import October 2020 BL & November 2020 ONSPD data

### DIFF
--- a/check-osni-downloads
+++ b/check-osni-downloads
@@ -15,7 +15,7 @@ export osni_folder="OSNI"
 export osni_prefix="OSNI_Open_Data_Largescale_Boundaries_"
 osni_present=0
 
-OSNI_URL=http://parlvid.mysociety.org/os/osni-dec-2015.tar.gz
+OSNI_URL=https://s3-eu-west-1.amazonaws.com/govuk-custom-formats-mapit-storage-production/source-data/2020-10/osni-dec-2015.tar.gz
 
 OSNI_FILE_NAME=$(basename $OSNI_URL)
 echo "Fetching OSNI data"

--- a/import-uk-onspd
+++ b/import-uk-onspd
@@ -8,13 +8,13 @@ set -e
 
 source ../mapit-scripts/find-mapit-managepy
 
-BD_LINE_URL=https://s3-eu-west-1.amazonaws.com/govuk-custom-formats-mapit-storage-production/source-data/2019-08/bdline_gb-2019-05.zip
-ONSPD_URL=https://s3-eu-west-1.amazonaws.com/govuk-custom-formats-mapit-storage-production/source-data/2020-02/ONSPD_FEB_2020_UK.zip
+BD_LINE_URL=https://s3-eu-west-1.amazonaws.com/govuk-custom-formats-mapit-storage-production/source-data/2020-11/bdline_gb-2020-10.zip
+ONSPD_URL=https://s3-eu-west-1.amazonaws.com/govuk-custom-formats-mapit-storage-production/source-data/2020-11/ONSPD_NOV_2020_UK.zip
 
 # Okay, let's start the import. Instructions taken from
 # http://code.mapit.mysociety.org/import/uk/
 
-$MANAGE mapit_generation_create --commit --desc "Initial import of BL 2019-05, ONSPD AUG_2019, and OSNI 2015-12"
+$MANAGE mapit_generation_create --commit --desc "Initial import of BL 2020-10, ONSPD NOV_2020, and OSNI 2015-12"
 $MANAGE loaddata uk
 
 # Boundary-Line


### PR DESCRIPTION
The updates are:
- ONSI URL points to the data in our S3 bucket (December 2015)
- Boundaryline URL points to latest October 2020 data
- ONSPD URL points to latest November 2020 data

Trello card: https://trello.com/c/afMgfqo2/2036-8-import-latest-mapit-data-using-docker